### PR TITLE
add sigar_get_machine_id() for linux and dummy funcs for other OS

### DIFF
--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -245,6 +245,11 @@ char *sigar_os_error_string(sigar_t *sigar, int err)
     }
 }
 
+char * sigar_get_machine_id(void) {
+  char machine_id[256] = "NOTIMPLEMENTED";
+  return machine_id;
+}
+
 #define PAGESHIFT(v) \
     ((v) << sigar->pagesize)
 

--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -292,6 +292,11 @@ int sigar_os_close(sigar_t *sigar)
     return SIGAR_OK;
 }
 
+char *sigar_get_machine_id(void) {
+  char machine_id[256] = "NOTIMPLEMENTED";
+  return machine_id;
+}
+
 char *sigar_os_error_string(sigar_t *sigar, int err)
 {
     switch (err) {

--- a/src/os/hpux/hpux_sigar.c
+++ b/src/os/hpux/hpux_sigar.c
@@ -279,6 +279,12 @@ static int sigar_pstat_getproc(sigar_t *sigar, sigar_pid_t pid)
     return SIGAR_OK;
 }
 
+
+char * sigar_get_machine_id(void) {
+  char machine_id[256] = "NOTIMPLEMENTED";
+  return machine_id;
+}
+
 int sigar_proc_mem_get(sigar_t *sigar, sigar_pid_t pid,
                        sigar_proc_mem_t *procmem)
 {

--- a/src/os/solaris/solaris_sigar.c
+++ b/src/os/solaris/solaris_sigar.c
@@ -263,6 +263,11 @@ static int zone_mem_get(sigar_t *sigar, sigar_mem_t *mem)
     return SIGAR_OK;
 }
 
+char * sigar_get_machine_id(void) {
+  char machine_id[256] = "NOTIMPLEMENTED";
+  return machine_id;
+}
+
 int sigar_mem_get(sigar_t *sigar, sigar_mem_t *mem)
 {
     kstat_ctl_t *kc = sigar->kc;

--- a/src/os/win32/win32_sigar.c
+++ b/src/os/win32/win32_sigar.c
@@ -266,6 +266,12 @@ static PERF_OBJECT_TYPE *get_perf_object_inst(sigar_t *sigar,
 #define get_perf_object(sigar, counter_key, err) \
     get_perf_object_inst(sigar, counter_key, 1, err)
 
+
+char * sigar_get_machine_id(void) {
+  char machine_id[256] = "NOTIMPLEMENTED";
+  return machine_id;
+}
+
 static int get_mem_counters(sigar_t *sigar, sigar_swap_t *swap, sigar_mem_t *mem)
 {
     int status;


### PR DESCRIPTION
This adds sigar_get_machine_id() functionality for Linux and placeholders for other operating systems.

I didn't go the D-Bus route with this version since it was for one call.  Instead it just queries the file containing the id exported by dbus.  I do plan to add that in the future along with investigating other D-Bus functionality.
