### PR TITLE
add uuid field to sys_info struct, populate with system uuid or best-effort

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,13 +2,16 @@ LINK = $(LIBTOOL) --mode=link $(CC) $(CFLAGS) $(LDFLAGS) -o $@
 
 AM_CPPFLAGS = @AM_CPPFLAGS@
 
-noinst_PROGRAMS = cpuinfo sigar_ps diskinfo
+noinst_PROGRAMS = cpuinfo diskinfo sysinfo sigar_ps
 
 cpuinfo_SOURCES = cpuinfo.c
 cpuinfo_LDADD = $(top_builddir)/src/libsigar.la
 
 diskinfo_SOURCES = diskinfo.c
 diskinfo_LDADD = $(top_builddir)/src/libsigar.la
+
+sysinfo_SOURCES = sysinfo.c
+sysinfo_LDADD = $(top_builddir)/src/libsigar.la
 
 sigar_ps_SOURCES = sigar_ps.c
 sigar_ps_LDADD = $(top_builddir)/src/libsigar.la

--- a/examples/sysinfo.c
+++ b/examples/sysinfo.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008 Hyperic, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sigar.h"
+
+int main(int argc, char **argv)
+{
+    int status;
+    sigar_t *sigar;
+    sigar_sys_info_t sysinfo;
+
+    sigar_open(&sigar);
+
+    status = sigar_sys_info_get(sigar, &sysinfo);
+
+    if (status != SIGAR_OK) {
+        printf("sys_info error: %d (%s)\n",
+               status, sigar_strerror(sigar, status));
+        exit(1);
+    }
+
+    printf("name: %s\n", sysinfo.name);
+    printf("version: %s\n", sysinfo.version);
+    printf("arch: %s\n", sysinfo.arch);
+    printf("machine: %s\n", sysinfo.machine);
+    printf("description: %s\n", sysinfo.description);
+    printf("patch_level: %s\n", sysinfo.patch_level);
+    printf("vendor: %s\n", sysinfo.vendor);
+    printf("vendor_version: %s\n", sysinfo.vendor_version);
+    printf("vendor_name: %s\n", sysinfo.vendor_name);
+    printf("vendor_code_name: %s\n", sysinfo.vendor_code_name);
+    printf("vendor_uuid: %s\n", sysinfo.uuid);
+
+    sigar_close(sigar);
+
+    return 0;
+}

--- a/include/sigar.h
+++ b/include/sigar.h
@@ -982,9 +982,13 @@ typedef struct {
     char vendor_version[SIGAR_SYS_INFO_LEN];
     char vendor_name[SIGAR_SYS_INFO_LEN];  /* utsname.sysname */
     char vendor_code_name[SIGAR_SYS_INFO_LEN];
+    char uuid[SIGAR_SYS_INFO_LEN];
 } sigar_sys_info_t;
 
 SIGAR_DECLARE(int) sigar_sys_info_get(sigar_t *sigar, sigar_sys_info_t *sysinfo);
+
+SIGAR_DECLARE(int) sigar_sys_info_get_uuid(sigar_t *sigar,
+                                           char uuid[SIGAR_SYS_INFO_LEN]);
 
 #define SIGAR_FQDN_LEN 512
 

--- a/src/os/aix/aix_sigar.c
+++ b/src/os/aix/aix_sigar.c
@@ -245,6 +245,11 @@ char *sigar_os_error_string(sigar_t *sigar, int err)
     }
 }
 
+int sigar_sys_info_get_uuid(sigar_t *sigar, char uuid[SIGAR_SYS_INFO_LEN])
+{
+    return SIGAR_ENOTIMPL;
+}
+
 #define PAGESHIFT(v) \
     ((v) << sigar->pagesize)
 

--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -212,6 +212,11 @@ static int kread(sigar_t *sigar, void *data, int size, long offset)
 }
 #endif
 
+int sigar_sys_info_get_uuid(sigar_t *sigar, char uuid[SIGAR_SYS_INFO_LEN])
+{
+    return SIGAR_ENOTIMPL;
+}
+
 int sigar_os_open(sigar_t **sigar)
 {
     int mib[2];

--- a/src/os/hpux/hpux_sigar.c
+++ b/src/os/hpux/hpux_sigar.c
@@ -625,6 +625,11 @@ int sigar_file_system_list_get(sigar_t *sigar,
     return SIGAR_OK;
 }
 
+int sigar_sys_info_get_uuid(sigar_t *sigar, char uuid[SIGAR_SYS_INFO_LEN])
+{
+    return SIGAR_ENOTIMPL;
+}
+
 static int create_fsdev_cache(sigar_t *sigar)
 {
     sigar_file_system_list_t fslist;

--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -3102,7 +3102,7 @@ int sigar_sys_info_get_uuid(sigar_t *sigar, char uuid[SIGAR_SYS_INFO_LEN])
         }
     }
 
-    return found ? SIGAR_OK : SIGAR_FIELD_NOTIMPL;
+    return found ? SIGAR_OK : SIGAR_ENOTIMPL;
 }
 
 /*

--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -3061,10 +3061,48 @@ static int get_linux_vendor_info(sigar_sys_info_t *info)
 int sigar_os_sys_info_get(sigar_t *sigar,
                           sigar_sys_info_t *sysinfo)
 {
-
     get_linux_vendor_info(sysinfo);
 
     return SIGAR_OK;
+}
+
+int sigar_sys_info_get_uuid(sigar_t *sigar, char uuid[SIGAR_SYS_INFO_LEN])
+{
+    int found = 0;
+    memset(uuid, 0, SIGAR_SYS_INFO_LEN);
+
+    /* TODO: query for this through dbus api */
+    FILE *fp = fopen("/etc/machine-id", "r");
+    if (fp) {
+        if (fgets(uuid, SIGAR_SYS_INFO_LEN - 1, fp)) {
+            found = 1;
+        }
+        fclose(fp);
+    } else {
+        /*
+         * fall back on disk uuid. We would prefer to use the 36 character UUID
+         * typical of hard disks, but the 22 character one used by iso9660
+         * devices will do for now. Most systems will use the dbus machine id
+         * as is.
+         */
+        DIR *ctx = opendir("/dev/disk/by-uuid");
+
+        if (ctx) {
+            struct dirent *data;
+            while ((data = readdir(ctx)) != NULL) {
+                const char *fs_uuid = data->d_name;
+                if (strlen(data->d_name) == 36 || strlen(data->d_name) == 22) {
+                    strncat(uuid, fs_uuid, SIGAR_SYS_INFO_LEN - strlen(fs_uuid) - 1);
+                    /* the first one encountered will suffice */
+                    found = 1;
+                    break;
+                }
+            }
+            closedir(ctx);
+        }
+    }
+
+    return found ? SIGAR_OK : SIGAR_FIELD_NOTIMPL;
 }
 
 /*

--- a/src/os/solaris/solaris_sigar.c
+++ b/src/os/solaris/solaris_sigar.c
@@ -1332,6 +1332,11 @@ static int sigar_proc_path_exe_get(sigar_t *sigar, sigar_pid_t pid,
     return SIGAR_OK;
 }
 
+int sigar_sys_info_get_uuid(sigar_t *sigar, char uuid[SIGAR_SYS_INFO_LEN])
+{
+    return SIGAR_ENOTIMPL;
+}
+
 static int proc_module_get_exe(void *data, char *name, int len)
 {
     sigar_proc_exe_t *procexe = (sigar_proc_exe_t *)data;

--- a/src/os/win32/win32_sigar.c
+++ b/src/os/win32/win32_sigar.c
@@ -1414,6 +1414,11 @@ sigar_int64_t sigar_time_now_millis(void)
     return sigar_FileTimeToTime(&time) / 1000;
 }
 
+int sigar_sys_info_get_uuid(sigar_t *sigar, char uuid[SIGAR_SYS_INFO_LEN])
+{
+    return SIGAR_ENOTIMPL;
+}
+
 SIGAR_DECLARE(int) sigar_proc_time_get(sigar_t *sigar, sigar_pid_t pid,
                                        sigar_proc_time_t *proctime)
 {

--- a/src/sigar.c
+++ b/src/sigar.c
@@ -370,14 +370,7 @@ SIGAR_DECLARE(int) sigar_sys_info_get(sigar_t *sigar,
 
     sigar_os_sys_info_get(sigar, sysinfo);
 
-    sigar_net_info_t netinfo;
-    char uuid[SIGAR_SYS_INFO_LEN] = { 0 };
-
-    sigar_net_info_get(sigar, &netinfo);
-    sigar_sys_info_get_uuid(sigar, uuid);
-
-    snprintf(sysinfo->uuid, sizeof(sysinfo->uuid), "%s.%s:%s",
-             netinfo.host_name, netinfo.domain_name, uuid);
+    sigar_sys_info_get_uuid(sigar, sysinfo->uuid);
 
     return SIGAR_OK;
 }

--- a/src/sigar.c
+++ b/src/sigar.c
@@ -370,6 +370,15 @@ SIGAR_DECLARE(int) sigar_sys_info_get(sigar_t *sigar,
 
     sigar_os_sys_info_get(sigar, sysinfo);
 
+    sigar_net_info_t netinfo;
+    char uuid[SIGAR_SYS_INFO_LEN] = { 0 };
+
+    sigar_net_info_get(sigar, &netinfo);
+    sigar_sys_info_get_uuid(sigar, uuid);
+
+    snprintf(sysinfo->uuid, sizeof(sysinfo->uuid), "%s.%s:%s",
+             netinfo.host_name, netinfo.domain_name, uuid);
+
     return SIGAR_OK;
 }
 

--- a/tests/t_sigar_sysinfo.c
+++ b/tests/t_sigar_sysinfo.c
@@ -59,6 +59,7 @@ TEST(test_sigar_sys_info_get) {
 	assert(sysinfo.vendor_version);
 	assert(sysinfo.vendor_name);
 	assert(sysinfo.vendor_code_name);
+	assert(sysinfo.uuid);
 
 	return 0;
 }


### PR DESCRIPTION
This adds a few things:
- a simple sysinfo test program
- defines sigar_sys_info_get_uuid to be defined per-OS
- adds uuid to the sys_info_t struct

The contents should be suitable for mixing with the meterpreter machine_id field.
